### PR TITLE
Hide legacy canvas buttons

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -37,36 +37,54 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
             overflow: hidden;
         }
 
-        .board-actions {
-            position: absolute;
-            top: 18px;
-            left: 20px;
+        .top-bar {
             display: flex;
-            gap: 10px;
-            z-index: 15;
+            align-items: center;
+            justify-content: space-between;
+            padding: 14px 24px;
+            background: rgba(15, 23, 42, 0.9);
+            color: #f8fafc;
+            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+            position: relative;
+            z-index: 20;
+            flex-shrink: 0;
         }
 
-        .board-actions button {
+        .top-bar-title {
+            font-size: 18px;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+        }
+
+        .top-menu {
+            display: flex;
+            gap: 12px;
+        }
+
+        .top-menu button {
             border: none;
-            background: rgba(15, 23, 42, 0.85);
+            background: rgba(248, 250, 252, 0.12);
             color: #f8fafc;
             font-weight: 600;
             font-size: 13px;
-            padding: 8px 14px;
+            padding: 8px 16px;
             border-radius: 999px;
             cursor: pointer;
-            box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
-            transition: transform 0.2s ease, box-shadow 0.2s ease;
-        }
-
-        .board-actions button:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 12px 22px rgba(15, 23, 42, 0.35);
-        }
-
-        .board-actions button:active {
-            transform: translateY(0);
             box-shadow: 0 6px 12px rgba(15, 23, 42, 0.3);
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+            backdrop-filter: blur(6px);
+        }
+
+        .top-menu button:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 18px rgba(15, 23, 42, 0.35);
+            background: rgba(248, 250, 252, 0.18);
+        }
+
+        .top-menu button:active {
+            transform: translateY(0);
+            box-shadow: 0 4px 10px rgba(15, 23, 42, 0.35);
+            background: rgba(248, 250, 252, 0.24);
         }
 
         #gearlab_canvas {
@@ -231,12 +249,18 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
 </head>
 <body onload="new window.gearlab.GearLab();">
     <div class="app-shell">
-        <div class="canvas-wrapper">
-            <div class="board-actions">
-                <button id="download-board" type="button">Descarregar board</button>
+        <header class="top-bar">
+            <div class="top-bar-title">GearLab</div>
+            <nav class="top-menu">
+                <button id="new-board" type="button">Board en blanc</button>
                 <button id="import-board" type="button">Carregar board</button>
-                <input id="board-file-input" type="file" accept=".glb,.gearlab,.json,.bin" hidden />
-            </div>
+                <button id="download-board" type="button">Descarregar board</button>
+                <button id="start-simulation" type="button">Iniciar simulació</button>
+                <button id="start-demo" type="button">Iniciar demo</button>
+            </nav>
+            <input id="board-file-input" type="file" accept=".glb,.gearlab,.json,.bin" hidden />
+        </header>
+        <div class="canvas-wrapper">
             <canvas id="gearlab_canvas"></canvas>
             <div id="gear-editor" class="gear-editor hidden">
                 <div class="gear-editor-row">
@@ -267,7 +291,7 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
         </div>
         <footer class="site-footer">
             <div class="wrap footer-inner">
-                <div data-i18n="footer.license" data-i18n-type="html">Generador Aleatori d'Exàmens © 2025 per <a href="mailto:aagust11@xtec.cat">aagust11@xtec.cat</a> amb l'assistència de la IA està llicenciat sota <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>.</div>
+                <div data-i18n="footer.license" data-i18n-type="html">GearLab © 2025 per <a href="mailto:aagust11@xtec.cat">aagust11@xtec.cat</a> amb l'assistència de la IA està llicenciat sota <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>.</div>
                 <div class="footer-meta">
                     <div data-i18n="footer.version">Versió 1 · Octubre 2025</div>
                     <div class="footer-icons">


### PR DESCRIPTION
## Summary
- replace the floating board action buttons with a persistent top navigation bar that exposes creating a blank board, loading, downloading, running the simulation, and launching the demo
- add supporting GearLab helpers to reuse simulation, blank board, and demo logic for the new controls
- update the footer branding to reference GearLab
- hide the legacy canvas icon buttons now that the header controls are available

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e1542c9cf88324a450b46a44d32aaf