### PR TITLE
Hide footer completely when collapsed

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,15 +217,16 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
             color: #1f2937;
             background: rgba(148, 163, 184, 0.18);
             flex-shrink: 0;
-            transition: max-height 0.3s ease, padding 0.3s ease;
+            transition: max-height 0.3s ease, padding 0.3s ease, background 0.3s ease;
             max-height: 120px;
-            overflow: hidden;
+            overflow: visible;
             position: relative;
         }
 
         .site-footer.collapsed {
-            max-height: 64px;
-            padding: 8px 16px;
+            max-height: 0;
+            padding: 0;
+            background: transparent;
         }
 
         .footer-inner {
@@ -247,6 +248,10 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
             transition: opacity 0.3s ease, max-height 0.3s ease;
             max-height: 60px;
             flex: 1 1 auto;
+        }
+
+        .site-footer.collapsed .footer-inner {
+            pointer-events: none;
         }
 
         .site-footer.collapsed .footer-content {
@@ -296,6 +301,17 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
         .footer-toggle:hover {
             background: rgba(15, 23, 42, 0.16);
             color: #0b1120;
+        }
+
+        .site-footer.collapsed .footer-toggle {
+            position: fixed;
+            bottom: 16px;
+            right: 24px;
+            margin: 0;
+            background: rgba(15, 23, 42, 0.12);
+            box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
+            pointer-events: auto;
+            z-index: 40;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- hide the footer container when it is collapsed so that no background remains visible
- keep the collapse toggle accessible by floating it when the footer is minimized

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2194834308324af5d12ffb96c95b2