### PR TITLE
Use static encryption password and custom file names

### DIFF
--- a/encryption-config.js
+++ b/encryption-config.js
@@ -1,0 +1,4 @@
+(function() {
+  "use strict";
+  window.GEARLAB_ENCRYPTION_PASSWORD = "gearlab-static-password-20240517";
+})();

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ Demo hand icon by momentum (http://momentumdesignlab.com/)
     <title>GearLab</title>
     <link rel="icon" type="image/png" href="img/Gear.png">
     <script type="text/javascript" src="hammer.min.js"></script>
+    <script type="text/javascript" src="encryption-config.js"></script>
     <script type="text/javascript" src="gearlab.js"></script>
     <style type="text/css">
         html, body {


### PR DESCRIPTION
## Summary
- add a configuration script that exposes a fixed encryption password
- update scene import/export to rely on the configured password and request a file name when downloading
- ensure downloaded scenes use the .glab extension by default

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e262ac9db48324b7b36d965be5b20d