### PR TITLE
Fix meshing pulleys to rotate in opposite directions when touching

### DIFF
--- a/gearlab.js
+++ b/gearlab.js
@@ -1864,14 +1864,9 @@
     };
 
     Board.prototype.calculateRatio = function(turningObject1, turningObject2, connectionType) {
-      var isPulleyMode;
-      isPulleyMode = window.gearlab.currentTransmissionMode === "pulleys";
       if (connectionType === ConnectionType.AXIS) {
         return 1;
       } else if (connectionType === ConnectionType.MESHING) {
-        if (isPulleyMode) {
-          return turningObject1.getCircumference() / turningObject2.getCircumference();
-        }
         return -turningObject1.getCircumference() / turningObject2.getCircumference();
       } else if (connectionType === ConnectionType.CHAIN_OUTSIDE) {
         return -turningObject1.getCircumference() / turningObject2.getCircumference();


### PR DESCRIPTION
### Motivation
- Touching wheels (meshing) should rotate in opposite directions even in pulley mode; the previous pulley-mode override made touching pulleys rotate the same way which is incorrect for direct contact.

### Description
- Removed the pulley-mode special-case in `Board.prototype.calculateRatio` so that `ConnectionType.MESHING` always returns a negative ratio (opposite rotation) while `CHAIN_OUTSIDE` behavior is unchanged, by editing `gearlab.js`.

### Testing
- Ran quick repository checks and inspections: `rg` to find usages, `sed` to view the modified region, `git status --short` to confirm changes, and committed the change with `git commit -m "Fix meshing rotation direction in pulley mode"`, all of which succeeded and updated `gearlab.js` (commit `89a168d`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b71294712883249f789865d5b2b47a)